### PR TITLE
feat: add EnrollmentDto for course enrollment data transfer

### DIFF
--- a/api/src/main/java/com/iep/api/dal/dto/EnrollmentDto.java
+++ b/api/src/main/java/com/iep/api/dal/dto/EnrollmentDto.java
@@ -1,0 +1,20 @@
+package com.iep.api.dal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link com.iep.api.dal.entity.Enrollment}
+ */
+@Schema(description = "課程綁定 DTO")
+@Data
+public class EnrollmentDto implements Serializable {
+    @Schema(description = "課程綁定 ID", example = "1")
+    Long id;
+    @Schema(description = "學生 sub", example = "7349e783-e2d8-4787-90a0-e44e4240ae44")
+    String studentSub;
+    @Schema(description = "課程 ID", example = "1")
+    Long courseId;
+}


### PR DESCRIPTION
- Introduced `EnrollmentDto` to facilitate data transfer for course enrollment, including fields for enrollment ID, student identifier, and course ID.
- Enhanced Swagger documentation with descriptions and examples for each field in the DTO.